### PR TITLE
Issue 15 - Isolator Modernization to Mesos 0.24.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The installation of the isolator is simple.  It is a matter of placing the `.so`
     --executor_registration_timeout=5mins \
     --ip=172.31.2.11 --work_dir=/tmp/mesos \
     --modules=file:///usr/lib/dvdi-mod.json \
-    --isolation="com_emc_mesos_DockerVolumeDriverIsolator" &
+    --isolation="com_emccode_mesos_DockerVolumeDriverIsolator" &
     ```
 
 

--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -54,10 +54,10 @@ using std::array;
 using namespace mesos;
 using namespace mesos::slave;
 
-using mesos::slave::ExecutorRunState;
+//using mesos::slave::ExecutorRunState;
 using mesos::slave::Isolator;
 using mesos::slave::IsolatorProcess;
-using mesos::slave::Limitation;
+//using mesos::slave::Limitation;
 
 //TODO temporary code until checkpoints are public by mesosphere dev
 #include <stout/path.hpp>
@@ -111,9 +111,7 @@ Try<Isolator*> DockerVolumeDriverIsolatorProcess::create(
           strings::startsWith(parameter.value(), "/") &&
           strings::endsWith(parameter.value(), "/")) {
         mountJsonFilename = parameter.value();
-
         mesosWorkingDir = parameter.value();
-
       } else {
         std::stringstream ss;
         ss << "DockerVolumeDriverIsolator " << DVDI_WORKDIR_PARAM_NAME
@@ -123,20 +121,16 @@ Try<Isolator*> DockerVolumeDriverIsolatorProcess::create(
     }
   }
 
-
   mountJsonFilename = path::join(getMetaRootDir(mesosWorkingDir), DVDI_MOUNTLIST_FILENAME);
   LOG(INFO) << "using " << mountJsonFilename;
 
-  process::Owned<IsolatorProcess> process(
-      new DockerVolumeDriverIsolatorProcess(parameters));
-
-  return new Isolator(process);
+  return new DockerVolumeDriverIsolatorProcess(parameters);
 }
 
 DockerVolumeDriverIsolatorProcess::~DockerVolumeDriverIsolatorProcess() {}
 
 Future<Nothing> DockerVolumeDriverIsolatorProcess::recover(
-    const list<ExecutorRunState>& states,
+    const list<ContainerState>& states,
     const hashset<ContainerID>& orphans)
 {
   LOG(INFO) << "DockerVolumeDriverIsolatorProcess recover() was called";
@@ -293,21 +287,21 @@ Future<Nothing> DockerVolumeDriverIsolatorProcess::recover(
     legacyMounts.put(elem.second.get()->getExternalMountId(), elem.second);
   }
 
-  foreach (const ExecutorRunState& state, states) {
+  foreach (const ContainerState& state, states) {
 
-    if (originalContainerMounts.contains(state.id.value())) {
+    if (originalContainerMounts.contains(state.container_id().value())) {
 
       // We found a task that is still running and has mounts.
-      LOG(INFO) << "Running container(" << state.id
+      LOG(INFO) << "Running container(" << state.container_id().value()
                 << ") re-identified on recover()";
-      LOG(INFO) << "State.directory is (" << state.directory << ")";
+      LOG(INFO) << "State.directory is (" << state.directory() << ")";
       std::list<process::Owned<ExternalMount>> mountsForContainer =
-          originalContainerMounts.get(state.id.value());
+          originalContainerMounts.get(state.container_id().value());
 
       for (const auto &iter : mountsForContainer) {
 
         // Copy task element to rebuild infos.
-        infos.put(state.id, iter);
+        infos.put(state.container_id(), iter);
         ExternalMountID id = iter->getExternalMountId();
         LOG(INFO) << "Re-identified a preserved mount, id is " << id;
         inUseMounts.put(iter->getExternalMountId(), iter);
@@ -352,8 +346,8 @@ bool DockerVolumeDriverIsolatorProcess::unmount(
     LOG(INFO) << "Invoking " << DVDCLI_UNMOUNT_CMD << " "
               << VOL_DRIVER_CMD_OPTION << em.deviceDriverName << " "
               << VOL_NAME_CMD_OPTION << em.volumeName;
-    std::ostringstream cmdOut;
-    Try<int> retcode = os::shell(&cmdOut, "%s %s%s %s%s",
+
+    Try<string> retcode = os::shell("%s %s%s %s%s ",
       DVDCLI_UNMOUNT_CMD,
       VOL_DRIVER_CMD_OPTION,
       em.deviceDriverName.c_str(),
@@ -361,32 +355,20 @@ bool DockerVolumeDriverIsolatorProcess::unmount(
       em.volumeName.c_str());
 
     if (retcode.isError()) {
-
       LOG(WARNING) << DVDCLI_UNMOUNT_CMD << " failed to execute on "
                    << callerLabelForLogging
                    << ", continuing on the assumption this volume was "
                    << "manually unmounted previously "
                    << retcode.error();
     } else {
-
-      if (retcode.get() == ECHILD) {
-        LOG(WARNING) << "Pclose could not obtain cmd execute status";
-      } else if (retcode.get() != 0) {
-        LOG(WARNING) << DVDCLI_UNMOUNT_CMD << " returned errorcode "
-                     << retcode.get()
-                     << ", continuing on the assumption this volume was "
-                     << "manually unmounted previously";
-      }
-
-      if (!cmdOut.str().empty()) {
-        LOG(INFO) << DVDCLI_UNMOUNT_CMD << " returned " << cmdOut.str();
-      }
+      LOG(INFO) << DVDCLI_UNMOUNT_CMD << " returned " << retcode.get();
     }
   } else {
     LOG(ERROR) << "failed to acquire a command processor for unmount on "
                << callerLabelForLogging;
     return false;
   }
+
   return true;
 }
 
@@ -415,8 +397,8 @@ std::string DockerVolumeDriverIsolatorProcess::mount(
               << VOL_DRIVER_CMD_OPTION << em.deviceDriverName << " "
               << VOL_NAME_CMD_OPTION << em.volumeName << " "
               << opts;
-    std::ostringstream cmdOut;
-    Try<int> retcode = os::shell(&cmdOut, "%s %s%s %s%s %s",
+
+    Try<string> retcode = os::shell("%s %s%s %s%s %s",
       DVDCLI_MOUNT_CMD,
       VOL_DRIVER_CMD_OPTION,
       em.deviceDriverName.c_str(),
@@ -429,16 +411,11 @@ std::string DockerVolumeDriverIsolatorProcess::mount(
                  << callerLabelForLogging
                  << retcode.error();
     } else {
-      if (retcode.get() == ECHILD) {
-        LOG(ERROR) << "Pclose could not obtain cmd execute status";
-      } else if (retcode.get() != 0) {
-        LOG(ERROR) << DVDCLI_MOUNT_CMD << " returned errorcode "
-                   << retcode.get();
-      } else if (strings::trim(cmdOut.str()).empty()) {
+      if (strings::trim(retcode.get()).empty()) {
         LOG(ERROR) << DVDCLI_MOUNT_CMD
                    << " returned an empty mountpoint name";
       } else {
-        mountpoint = strings::trim(cmdOut.str());
+        mountpoint = strings::trim(retcode.get());
         LOG(INFO) << DVDCLI_MOUNT_CMD << " returned mountpoint:"
                   << mountpoint;
       }
@@ -494,11 +471,10 @@ bool DockerVolumeDriverIsolatorProcess::containsProhibitedChars(
 // there are any problems parsing or mounting even one
 // mount, we want to exit with an error and no new
 // mounted volumes. Goal: make all mounts or none.
-Future<Option<CommandInfo>> DockerVolumeDriverIsolatorProcess::prepare(
+Future<Option<ContainerPrepareInfo>> DockerVolumeDriverIsolatorProcess::prepare(
   const ContainerID& containerId,
   const ExecutorInfo& executorInfo,
   const string& directory,
-  const Option<string>& rootfs,
   const Option<string>& user)
 {
   LOG(INFO) << "Preparing external storage for container: "
@@ -735,12 +711,12 @@ Future<Option<CommandInfo>> DockerVolumeDriverIsolatorProcess::prepare(
   return None();
 }
 
-Future<Limitation> DockerVolumeDriverIsolatorProcess::watch(
+Future<ContainerLimitation> DockerVolumeDriverIsolatorProcess::watch(
     const ContainerID& containerId)
 {
   // No-op, for now.
 
-  return Future<Limitation>();
+  return Future<ContainerLimitation>();
 }
 
 Future<Nothing> DockerVolumeDriverIsolatorProcess::update(

--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -37,7 +37,7 @@
 namespace mesos {
 namespace slave {
 
-class DockerVolumeDriverIsolatorProcess: public mesos::slave::IsolatorProcess {
+class DockerVolumeDriverIsolatorProcess: public mesos::slave::Isolator {
 public:
   static Try<mesos::slave::Isolator*> create(const Parameters& parameters);
 
@@ -51,7 +51,7 @@ public:
   // of container states which will assist in recovery,
   // when this is available, code should use it.
   virtual process::Future<Nothing> recover(
-    const std::list<mesos::slave::ExecutorRunState>& states,
+    const std::list<ContainerState>& states,
     const hashset<ContainerID>& orphans);
 
   // Prepare runs BEFORE a task is started
@@ -72,11 +72,10 @@ public:
   //    this call is synchronous, and returns 0 if success
   //    actual call is defined below in DVDCLI_MOUNT_CMD
   // 5. Add entry to hashmap that contains root mountpath indexed by ContainerId
-  virtual process::Future<Option<CommandInfo>> prepare(
+  virtual process::Future<Option<ContainerPrepareInfo>> prepare(
     const ContainerID& containerId,
     const ExecutorInfo& executorInfo,
     const std::string& directory,
-    const Option<std::string>& rootfs,
     const Option<std::string>& user);
 
   // Nothing will be done at task start
@@ -85,7 +84,7 @@ public:
       pid_t pid);
 
   // no-op, mount occurs at prepare
-  virtual process::Future<mesos::slave::Limitation> watch(
+  virtual process::Future<ContainerLimitation> watch(
     const ContainerID& containerId);
 
   // no-op, nothing enforced

--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -46,10 +46,7 @@ public:
   // Slave recovery is a feature of Mesos that allows task/executors
   // to keep running if a slave process goes down, AND
   // allows the slave process to reconnect with already running
-  // slaves when it restarts
-  // TODO This interface will change post 0.23.0 to pass a list of
-  // of container states which will assist in recovery,
-  // when this is available, code should use it.
+  // slaves when it restartss
   virtual process::Future<Nothing> recover(
     const std::list<ContainerState>& states,
     const hashset<ContainerID>& orphans);


### PR DESCRIPTION
Brought the existing Isolator code base up from version 0.23.X to 0.24.X.

Notable changes:
* IsolatorProcess class has been deprecated. Must implement and extend the Isolator class
* In receover() the object being passed in was of type ExecutorRunState but now it is of type ContainerState. The implement is similar but has some subtle differences
* In prepare(), the const Option<std::string>& rootfs parameter is no longer being passed into the function
* Update example in documentation to reflect the real Isolator string
