### PR TITLE
Brought the existing Isolator code base up from version 0.23.X to 0.2…

### DIFF
--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -54,10 +54,8 @@ using std::array;
 using namespace mesos;
 using namespace mesos::slave;
 
-//using mesos::slave::ExecutorRunState;
 using mesos::slave::Isolator;
 using mesos::slave::IsolatorProcess;
-//using mesos::slave::Limitation;
 
 //TODO temporary code until checkpoints are public by mesosphere dev
 #include <stout/path.hpp>


### PR DESCRIPTION
…4.X.

Notable changes:
* IsolatorProcess class has been deprecated. Must implement and extend the Isolator class
* In receover() the object being passed in was of type ExecutorRunState but now it is of type ContainerState. The implement is similar but has some subtle differences
* In prepare(), the const Option<std::string>& rootfs parameter is no longer being passed into the function
* Update example in documentation to reflect the real Isolator string