### PR TITLE
Issue16 - Isolator modernization to 0.25.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ script:
   - make protobuf
   - make picojson
   - make mesos-0.24.1
+  - make mesos-0.25.0
   - make autoconf
   - make isolator-0.24.1
+  - make isolator-0.25.0
   - make bintray
 
 addons:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # MESOS_VERSIONS is a list of space, separated versions of mesos that
 # will be built.
-MESOS_VERSIONS := 0.24.1
+MESOS_VERSIONS := 0.24.1 0.25.0
 
 # ISO_VERSIONS is either equal to or a subset of the MESOS_VERSIONS
 # list. The versions in this list are the versions of Mesos against
 # which to build the isolator module.
-ISO_VERSIONS := 0.24.1
+ISO_VERSIONS := 0.24.1 0.25.0
 
 ########################################################################
 ##                             MAKEFLAGS                              ##

--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -55,7 +55,6 @@ using namespace mesos;
 using namespace mesos::slave;
 
 using mesos::slave::Isolator;
-using mesos::slave::IsolatorProcess;
 
 //TODO temporary code until checkpoints are public by mesosphere dev
 #include <stout/path.hpp>
@@ -64,7 +63,6 @@ using mesos::slave::IsolatorProcess;
 using namespace mesos::internal::slave::paths;
 using namespace mesos::internal::slave::state;
 //TODO temporary code until checkpoints are public by mesosphere dev
-
 
 const char DockerVolumeDriverIsolatorProcess::prohibitedchars[NUM_PROHIBITED]  =
 {
@@ -76,7 +74,6 @@ const char DockerVolumeDriverIsolatorProcess::prohibitedchars[NUM_PROHIBITED]  =
 
 std::string DockerVolumeDriverIsolatorProcess::mountJsonFilename;
 std::string DockerVolumeDriverIsolatorProcess::mesosWorkingDir;
-
 
 
 DockerVolumeDriverIsolatorProcess::DockerVolumeDriverIsolatorProcess(

--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -37,6 +37,29 @@
 namespace mesos {
 namespace slave {
 
+static constexpr const char* REXRAY_MOUNT_PREFIX       = "/var/lib/rexray/volumes/";
+static constexpr const char* DVDCLI_MOUNT_CMD          = "/usr/bin/dvdcli mount";
+static constexpr const char* DVDCLI_UNMOUNT_CMD        = "/usr/bin/dvdcli unmount";
+
+static constexpr const char* VOL_NAME_CMD_OPTION       = "--volumename=";
+static constexpr const char* VOL_DRIVER_CMD_OPTION     = "--volumedriver=";
+static constexpr const char* VOL_OPTS_CMD_OPTION       = "--volumeopts=";
+static constexpr const char* VOL_DRIVER_DEFAULT        = "rexray";
+
+static constexpr const char* VOL_NAME_ENV_VAR_NAME     = "DVDI_VOLUME_NAME";
+static constexpr const char* VOL_DRIVER_ENV_VAR_NAME   = "DVDI_VOLUME_DRIVER";
+static constexpr const char* VOL_OPTS_ENV_VAR_NAME     = "DVDI_VOLUME_OPTS";
+static constexpr const char* JSON_VOLS_ENV_VAR_NAME    = "DVDI_VOLS_JSON_ARRAY";
+
+//TODO this is temporary until the working_dir is exposed by mesosphere dev
+static constexpr const char* DVDI_MOUNTLIST_DEFAULT_DIR= "/tmp/mesos/";
+static constexpr const char* DVDI_MOUNTLIST_FILENAME   = "dvdimounts.json";
+static constexpr const char* DVDI_WORKDIR_PARAM_NAME   = "work_dir";
+
+//TODO this is temporary until the working_dir is exposed by mesosphere dev
+static constexpr const char* DEFAULT_WORKING_DIR       = "/tmp/mesos";
+
+
 class DockerVolumeDriverIsolatorProcess: public mesos::slave::Isolator {
 public:
   static Try<mesos::slave::Isolator*> create(const Parameters& parameters);
@@ -191,28 +214,6 @@ private:
   '<', '>', '|', '`', '$', '\'',
   '?', '^', '&', ' ', '{', '\"',
   '}', '[', ']', '\n', '\t', '\v', '\b', '\r', '\\' };*/
-
-  static constexpr const char* REXRAY_MOUNT_PREFIX       = "/var/lib/rexray/volumes/";
-  static constexpr const char* DVDCLI_MOUNT_CMD          = "/usr/bin/dvdcli mount";
-  static constexpr const char* DVDCLI_UNMOUNT_CMD        = "/usr/bin/dvdcli unmount";
-
-  static constexpr const char* VOL_NAME_CMD_OPTION       = "--volumename=";
-  static constexpr const char* VOL_DRIVER_CMD_OPTION     = "--volumedriver=";
-  static constexpr const char* VOL_OPTS_CMD_OPTION       = "--volumeopts=";
-  static constexpr const char* VOL_DRIVER_DEFAULT        = "rexray";
-
-  static constexpr const char* VOL_NAME_ENV_VAR_NAME     = "DVDI_VOLUME_NAME";
-  static constexpr const char* VOL_DRIVER_ENV_VAR_NAME   = "DVDI_VOLUME_DRIVER";
-  static constexpr const char* VOL_OPTS_ENV_VAR_NAME     = "DVDI_VOLUME_OPTS";
-  static constexpr const char* JSON_VOLS_ENV_VAR_NAME    = "DVDI_VOLS_JSON_ARRAY";
-
-  //TODO this is temporary until the working_dir is exposed by mesosphere dev
-  static constexpr const char* DVDI_MOUNTLIST_DEFAULT_DIR= "/tmp/mesos/";
-  static constexpr const char* DVDI_MOUNTLIST_FILENAME   = "dvdimounts.json";
-  static constexpr const char* DVDI_WORKDIR_PARAM_NAME   = "work_dir";
-
-  //TODO this is temporary until the working_dir is exposed by mesosphere dev
-  static constexpr const char* DEFAULT_WORKING_DIR       = "/tmp/mesos";
 
   static std::string mountJsonFilename;
   static std::string mesosWorkingDir;


### PR DESCRIPTION
### Issue 16 - Isolator Modernization to Mesos 0.25.0

Brought the existing Isolator code base up from version 0.24.1 to 0.25.0.
0.25.0 will also compile using the 0.24.1 framework

Notable changes:
* Had to move the constants outside of the class to resolve some unresolved
symbols at runtime
